### PR TITLE
Add command 'ah'

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Runs a script inside the DOM of the current visited webpage. The output or resul
 |--------------|------------|-------------|
 | ```a```      | Inject     | Annotations of all anchors  |
 | ```ais```    | Open       | [Archive.is webpage capture](http://archive.is/) |
-| ```ah```    | Open       | [Ahrefs Site Explorer](ahrefs.com) |
+| ```ah```    | Open       | [Ahrefs Site Explorer](https://ahrefs.com/) |
 | ```ampb```   | Open       | [AMPBench](https://ampbench.appspot.com/validate?url=https%3A%2F%2Fampbyexample.com%2F) |
 | ```ampv```   | Open       | [AMP Validator](https://validator.ampproject.org/) |
 | ```ampt```   | Open       | [Google Search Console AMP Test](https://search.google.com/search-console/amp)  |

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Runs a script inside the DOM of the current visited webpage. The output or resul
 |--------------|------------|-------------|
 | ```a```      | Inject     | Annotations of all anchors  |
 | ```ais```    | Open       | [Archive.is webpage capture](http://archive.is/) |
+| ```ah```    | Open       | [Ahrefs Site Explorer](ahrefs.com) |
 | ```ampb```   | Open       | [AMPBench](https://ampbench.appspot.com/validate?url=https%3A%2F%2Fampbyexample.com%2F) |
 | ```ampv```   | Open       | [AMP Validator](https://validator.ampproject.org/) |
 | ```ampt```   | Open       | [Google Search Console AMP Test](https://search.google.com/search-console/amp)  |

--- a/src/commands.html
+++ b/src/commands.html
@@ -152,6 +152,11 @@
                         <td align="left"><a class="table__link" href="https://majestic.com/">Majestic Backlink Checker</a></td>
                     </tr>
                     <tr>
+                        <td align="left">ah</td>
+                        <td align="center">Open</td>
+                        <td align="left"><a class="table__link" href="https://majestic.com/">Ahrefs Site Explorer</a></td>
+                    </tr>
+                    <tr>
                         <td align="left">wbm</td>
                         <td align="center">Open</td>
                         <td align="left"><a class="table__link" href="http://archive.org/web/">Wayback Machine</a></td>

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -22,6 +22,10 @@ chrome.omnibox.onInputChanged.addListener(function(text, suggest) {
             description: "<dim>command </dim><match>a</match> - Show visual annotations of all anchors"
         },
         {
+            content: "ah",
+            description: "<dim>command </dim><match>ah</match> - Check current URL in Ahrefs Site Explorer"
+        },
+        {
             content: "ais",
             description: "<dim>command </dim><match>ais</match> - Check current URL in Archive.is"
         },

--- a/src/js/commands/ah.js
+++ b/src/js/commands/ah.js
@@ -1,0 +1,9 @@
+/**
+ * ah.js 1.0
+ * Check current (exact) URL in Ahrefs Site Explorer
+ */
+
+(function() {
+    'use strict';
+    window.open('https://ahrefs.com/site-explorer/overview/v2/prefix/fresh?target=' + encodeURIComponent(document.location.href));
+})();


### PR DESCRIPTION
Adds an open command `ah` that opens the current URL in Ahrefs Site Explorer.