### PR TITLE
Add img command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Runs a script inside the DOM of the current visited webpage. The output or resul
 | ```hl```     | Open       | [hreflang.ninja](http://hreflang.ninja/)  |
 | ```hx```     | Inject     | Annotations of heading structure  |
 | ```hxa```    | Inject     | Annotations of heading structure and anchors  |
+| ```img```    | Inject     | Highlight images on the page that are missing an alt tag  |
 | ```ld```     | Runs       | Show all JSON-LD script tags for the current tab |
 | ```mft```     | Open      | [Google Mobile-Friendly Test](https://search.google.com/search-console/mobile-friendly)  |
 | ```mj```     | Open       | [Majestic Backlink Checker](https://majestic.com/)  |

--- a/src/commands.html
+++ b/src/commands.html
@@ -174,6 +174,11 @@
                         <td align="left">Annotations of heading structure and anchors</td>
                     </tr>
                     <tr>
+                        <td align="left">img</td>
+                        <td align="center">Inject</td>
+                        <td align="left">Highlight images on the page that are missing an alt tag</td>
+                    </tr>
+                    <tr>
                         <td align="left">ld</td>
                         <td align="center">Run</td>
                         <td align="left">Show all JSON-LD script tags for the current tab</td>

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -104,6 +104,11 @@ chrome.omnibox.onInputChanged.addListener(function(text, suggest) {
         "<dim>command </dim><match>hxa</match> - Show visual annotations of the HTML heading structure and anchors"
     },
     {
+      content: "img",
+      description:
+        "<dim>command </dim><match>img</match> - Highlight images on the page that are missing an alt tag"
+    },
+    {
       content: "ld",
       description:
         "<dim>command </dim><match>ld</match> - Show contents of JSON-LD script tags for the current URL in the console"

--- a/src/js/commands/img.js
+++ b/src/js/commands/img.js
@@ -1,0 +1,17 @@
+/**
+ * img.js 1.0
+ * Find images on page without alt tags
+ */
+
+(function() {
+  "use strict";
+
+  var images = document.getElementsByTagName('img');
+  for (var i = 0; i < images.length; i++) {
+    if (images[i].alt.length === 0) {
+      images[i].style.filter = 'grayscale(100%)';
+      images[i].style.outline = '3px dashed purple';
+    }
+  }
+
+})();


### PR DESCRIPTION
Highlight images on the page that are missing an alt tag.

This adds an outline _and_ makes the image grayscale. I couldn't find a better way to "highlight" the image. There are still edge cases with this:

* Outline doesn't always work depending on the parent element
* You don't notice a grayscale change if the image is already monochrome